### PR TITLE
Removed hard-coded termux reference from the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 # Install script for Findsploit by @xer0dayz
 # https://xerosecurity.com 
 #
-
-SPLOIT_INSTALL_DIR=/data/data/com.termux/files/home/Searchsploit
+mkdir -p ~/.config/searchsploit
+SPOLIT_INSTALL_DIR=~/.config/searchsploit
 
 OKBLUE='\033[94m'
 OKRED='\033[91m'


### PR DESCRIPTION
The install script previously had a hard-coded reference to termux as the SPLOIT_INSTALL_DIR variable. This was removed and changed to be more generic, since not everyone uses termux.